### PR TITLE
feat: add setInitialValue config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.7.0](https://github.com/ngneat/bind-query-params/compare/v1.6.2...v1.7.0) (2021-09-29)
+
+
+### Features
+
+* 🎸 syncAllDefs ([45907ec](https://github.com/ngneat/bind-query-params/commit/45907ec611a2928abedf88bed8af86fde7e8520a))
+
 ### [1.6.2](https://github.com/ngneat/bind-query-params/compare/v1.6.1...v1.6.2) (2021-09-06)
 
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Specify the control value type. Available options are:
 `boolean`, `array`, `number`, `string` and `object`.
 Before updating the control with the value, the manager will parse it based on the provided `type`.
 
-### `setInitialValue`
+### `syncInitialValue`
 
-Whether to sync the initial control value in the URL.
+Whether to sync the initial control value in the URL. Relevant only when using the `modelToUrl` strategy. 
 
 ### `parser`
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const def = { serializer: (value) => (value instanceof Date ? value.toISOString(
 
 When working with async control values, for example, a dropdown list that its options come from the server, we cannot immediately update the control.
 
-In this cases, we can provide the `modelToUrl` strategy, that will not update the control value when the page loads. When the data is available we can call the `manager.syncDefs()` method that'll update the controls based on the current query params:
+In these cases, we can provide the `modelToUrl` strategy, that will not update the control value when the page loads. When the data is available we can call the `manager.syncDefs()` or `manager.syncAllDefs()` method that'll update the controls based on the current query params:
 
 ```ts
 @Component()
@@ -131,7 +131,10 @@ export class MyComponent {
     service.getUsers().subscribe((users) => {
       // Initalize the dropdown
       this.users = users;
+      // Sync specific controls use:
       this.manager.syncDefs('users');
+      // Sync all controls
+      this.manager.syncAllDefs();
     });
   }
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,7 @@ Before updating the control with the value, the manager will parse it based on t
 
 ### `setInitialValue`
 
-Rather the value should be inherited from the formControl or not.
-When set to true, The initial value will be the same as the form control one.
-When set to false, There will be no initial value and the value we'll be set from the formControl valueChanges.
-Default is false.
+Whether to sync the initial control value in the URL.
 
 ### `parser`
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Specify the control value type. Available options are:
 `boolean`, `array`, `number`, `string` and `object`.
 Before updating the control with the value, the manager will parse it based on the provided `type`.
 
+### `setInitialValue`
+
+Rather the value should be inherited from the formControl or not.
+When set to true, The initial value will be the same as the form control one.
+When set to false, There will be no initial value and the value we'll be set from the formControl valueChanges.
+Default is false.
+
 ### `parser`
 
 Provide a custom parser. For example, the default `array` parser converts the value to an `array` of strings. If we need it to be an array of numbers, we can pass the following `parser`:

--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
   },
   "lint-staged": {
     "*.{js,json,css,scss,ts,html,component.html}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "husky": {

--- a/projects/ngneat/bind-query-params/package.json
+++ b/projects/ngneat/bind-query-params/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngneat/bind-query-params",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Sync URL Query Params with Angular Form Controls",
   "dependencies": {
     "tslib": "^2.0.0",

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsFactory.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsFactory.ts
@@ -1,14 +1,18 @@
 import { Inject, Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BindQueryParamsManager } from './BindQueryParamsManager';
 import { BIND_QUERY_PARAMS_OPTIONS } from './options';
 import { BindQueryParamsOptions, QueryParamParams } from './types';
 
 @Injectable({ providedIn: 'root' })
 export class BindQueryParamsFactory {
-  constructor(private router: Router, @Inject(BIND_QUERY_PARAMS_OPTIONS) private options: BindQueryParamsOptions) {}
+  constructor(
+    private router: Router,
+    private activeRoute: ActivatedRoute,
+    @Inject(BIND_QUERY_PARAMS_OPTIONS) private options: BindQueryParamsOptions
+  ) {}
 
   create<T>(defs: QueryParamParams<T>[] | QueryParamParams<T>): BindQueryParamsManager<T> {
-    return new BindQueryParamsManager<T>(this.router, defs, this.options);
+    return new BindQueryParamsManager<T>(this.router, this.activeRoute, defs, this.options);
   }
 }

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
@@ -29,11 +29,13 @@ export class BindQueryParamsManager<T = any> {
   }
 
   onInit() {
-    this.updateControl(this.defs, { emitEvent: true }, this.shouldSyncInitialValue);
+    this.updateControl(this.defs, { emitEvent: true }, shouldSyncInitialValue);
 
     const controls = this.defs.map((def) => {
-      return this.group.get(def.path)!.valueChanges.pipe(
-        this.shouldSyncInitialValue(def) ? startWith(this.group.get(def.path)?.value) : identity,
+      const control = this.group.get(def.path)!;
+
+      return control.valueChanges.pipe(
+        shouldSyncInitialValue(def) ? startWith(control.value) : identity,
         map((value) => ({
           def,
           value,
@@ -162,8 +164,8 @@ export class BindQueryParamsManager<T = any> {
       this.group.patchValue(value, options);
     }
   }
+}
 
-  private shouldSyncInitialValue(def: QueryParamDef) {
-    return def.strategy === 'twoWay' || def.syncInitialValue;
-  }
+function shouldSyncInitialValue(def: QueryParamDef) {
+  return def.strategy === 'twoWay' || def.syncInitialValue;
 }

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
@@ -2,7 +2,7 @@ import { FormGroup } from '@angular/forms';
 import { merge, Subject, identity } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { coerceArray, resolveParams } from './utils';
-import { auditTime, map, startWith, takeUntil } from 'rxjs/operators';
+import { auditTime, map, pairwise, startWith, takeUntil } from 'rxjs/operators';
 import { BindQueryParamsOptions, QueryParamParams, ResolveParamsOption, SyncDefsOptions } from './types';
 import { QueryParamDef } from './QueryParamDef';
 import set from 'lodash.set';
@@ -29,11 +29,11 @@ export class BindQueryParamsManager<T = any> {
   }
 
   onInit() {
-    this.updateControl(this.defs, { emitEvent: true }, (def) => def.strategy === 'twoWay' || def.syncInitialValue);
+    this.updateControl(this.defs, { emitEvent: true }, this.shouldSyncInitialValue);
 
     const controls = this.defs.map((def) => {
       return this.group.get(def.path)!.valueChanges.pipe(
-        def.strategy === 'twoWay' || def.syncInitialValue ? startWith(this.group.get(def.path)?.value) : identity,
+        this.shouldSyncInitialValue(def) ? startWith(this.group.get(def.path)?.value) : identity,
         map((value) => ({
           def,
           value,
@@ -61,9 +61,14 @@ export class BindQueryParamsManager<T = any> {
     const twoWaySyncDef: QueryParamDef<T>[] = this.defs.filter(({ strategy }: QueryParamDef) => strategy === 'twoWay');
 
     if (twoWaySyncDef.length) {
-      this.activeRoute.queryParams.pipe(takeUntil(this.$destroy)).subscribe(() => {
-        this.updateControl(twoWaySyncDef, { emitEvent: false });
-      });
+      this.activeRoute.queryParams
+        .pipe(pairwise(), takeUntil(this.$destroy))
+        .subscribe(([prevQueryParams, curQueryParams]) => {
+          let paramSDiff = twoWaySyncDef.filter(
+            ({ queryKey }) => prevQueryParams[queryKey] !== curQueryParams[queryKey]
+          );
+          this.updateControl(paramSDiff, { emitEvent: true });
+        });
     }
   }
 
@@ -153,5 +158,9 @@ export class BindQueryParamsManager<T = any> {
     if (Object.keys(value).length) {
       this.group.patchValue(value, options);
     }
+  }
+
+  private shouldSyncInitialValue(def: QueryParamDef) {
+    return def.strategy === 'twoWay' || def.syncInitialValue;
   }
 }

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
@@ -64,10 +64,13 @@ export class BindQueryParamsManager<T = any> {
       this.activeRoute.queryParams
         .pipe(pairwise(), takeUntil(this.$destroy))
         .subscribe(([prevQueryParams, curQueryParams]) => {
-          let paramSDiff = twoWaySyncDef.filter(
+          let paramsDiff = twoWaySyncDef.filter(
             ({ queryKey }) => prevQueryParams[queryKey] !== curQueryParams[queryKey]
           );
-          this.updateControl(paramSDiff, { emitEvent: true });
+
+          if (paramsDiff.length) {
+            this.updateControl(paramsDiff, { emitEvent: true });
+          }
         });
     }
   }

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
@@ -32,7 +32,7 @@ export class BindQueryParamsManager<T = any> {
 
     const controls = this.defs.map((def) => {
       return this.group.get(def.path)!.valueChanges.pipe(
-        def.setInitialValue ? startWith(this.group.get(def.path)?.value) : identity,
+        def.syncInitialValue ? startWith(this.group.get(def.path)?.value) : identity,
         map((value) => ({
           def,
           value,

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
@@ -1,8 +1,8 @@
 import { FormGroup } from '@angular/forms';
-import { merge, Subject } from 'rxjs';
+import { merge, Subject, identity } from 'rxjs';
 import { Router } from '@angular/router';
 import { coerceArray, resolveParams } from './utils';
-import { auditTime, map, takeUntil } from 'rxjs/operators';
+import { auditTime, map, startWith, takeUntil } from 'rxjs/operators';
 import { BindQueryParamsOptions, QueryParamParams, ResolveParamsOption, SyncDefsOptions } from './types';
 import { QueryParamDef } from './QueryParamDef';
 import set from 'lodash.set';
@@ -32,6 +32,7 @@ export class BindQueryParamsManager<T = any> {
 
     const controls = this.defs.map((def) => {
       return this.group.get(def.path)!.valueChanges.pipe(
+        def.setInitialValue ? startWith(this.group.get(def.path)?.value) : identity,
         map((value) => ({
           def,
           value,

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
@@ -1,6 +1,6 @@
 import { FormGroup } from '@angular/forms';
 import { merge, Subject, identity } from 'rxjs';
-import { Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
 import { coerceArray, resolveParams } from './utils';
 import { auditTime, map, startWith, takeUntil } from 'rxjs/operators';
 import { BindQueryParamsOptions, QueryParamParams, ResolveParamsOption, SyncDefsOptions } from './types';
@@ -32,7 +32,7 @@ export class BindQueryParamsManager<T = any> {
 
     const controls = this.defs.map((def) => {
       return this.group.get(def.path)!.valueChanges.pipe(
-        def.syncInitialValue ? startWith(this.group.get(def.path)?.value) : identity,
+        def.syncOnlyInitialValue ? startWith(this.group.get(def.path)?.value) : identity,
         map((value) => ({
           def,
           value,
@@ -56,6 +56,18 @@ export class BindQueryParamsManager<T = any> {
         this.updateQueryParams(resolveParams(buffer));
         buffer = [];
       });
+
+    const twoWaySyncDef: QueryParamDef<T>[] = this.defs.filter(
+      ({ strategy, syncOnlyInitialValue }: QueryParamDef) => strategy === 'twoWay' && !syncOnlyInitialValue
+    );
+
+    if (twoWaySyncDef.length > 0) {
+      this.router.events.pipe(takeUntil(this.$destroy)).subscribe((event) => {
+        if (event instanceof NavigationEnd) {
+          this.updateControl(twoWaySyncDef, { emitEvent: false });
+        }
+      });
+    }
   }
 
   destroy() {

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
@@ -1,8 +1,8 @@
 import { FormGroup } from '@angular/forms';
 import { merge, Subject, identity } from 'rxjs';
-import { NavigationEnd, Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { coerceArray, resolveParams } from './utils';
-import { auditTime, filter, map, startWith, takeUntil } from 'rxjs/operators';
+import { auditTime, map, startWith, takeUntil } from 'rxjs/operators';
 import { BindQueryParamsOptions, QueryParamParams, ResolveParamsOption, SyncDefsOptions } from './types';
 import { QueryParamDef } from './QueryParamDef';
 import set from 'lodash.set';
@@ -21,6 +21,7 @@ export class BindQueryParamsManager<T = any> {
 
   constructor(
     private router: Router,
+    private activeRoute: ActivatedRoute,
     defs: QueryParamParams<T>[] | QueryParamParams<T>,
     private options: BindQueryParamsOptions
   ) {
@@ -59,15 +60,10 @@ export class BindQueryParamsManager<T = any> {
 
     const twoWaySyncDef: QueryParamDef<T>[] = this.defs.filter(({ strategy }: QueryParamDef) => strategy === 'twoWay');
 
-    if (twoWaySyncDef.length > 0) {
-      this.router.events
-        .pipe(
-          filter((event) => event instanceof NavigationEnd),
-          takeUntil(this.$destroy)
-        )
-        .subscribe(() => {
-          this.updateControl(twoWaySyncDef, { emitEvent: false });
-        });
+    if (twoWaySyncDef.length) {
+      this.activeRoute.queryParams.pipe(takeUntil(this.$destroy)).subscribe(() => {
+        this.updateControl(twoWaySyncDef, { emitEvent: false });
+      });
     }
   }
 

--- a/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
+++ b/projects/ngneat/bind-query-params/src/lib/BindQueryParamsManager.ts
@@ -3,7 +3,7 @@ import { merge, Subject } from 'rxjs';
 import { Router } from '@angular/router';
 import { coerceArray, resolveParams } from './utils';
 import { auditTime, map, takeUntil } from 'rxjs/operators';
-import { BindQueryParamsOptions, QueryParamParams, ResolveParamsOption } from './types';
+import { BindQueryParamsOptions, QueryParamParams, ResolveParamsOption, SyncDefsOptions } from './types';
 import { QueryParamDef } from './QueryParamDef';
 import set from 'lodash.set';
 
@@ -79,10 +79,12 @@ export class BindQueryParamsManager<T = any> {
     return result;
   }
 
-  syncDefs(
-    queryKeys: (keyof T & string) | (keyof T & string)[],
-    options: { emitEvent: boolean } = { emitEvent: true }
-  ) {
+  syncAllDefs(options: SyncDefsOptions = { emitEvent: true }) {
+    const allKeys = this.defs.map((def) => def.queryKey);
+    this.syncDefs(allKeys, options);
+  }
+
+  syncDefs(queryKeys: (keyof T & string) | (keyof T & string)[], options: SyncDefsOptions = { emitEvent: true }) {
     const defs: QueryParamDef<T>[] = [];
 
     coerceArray(queryKeys).forEach((key) => {

--- a/projects/ngneat/bind-query-params/src/lib/QueryParamDef.ts
+++ b/projects/ngneat/bind-query-params/src/lib/QueryParamDef.ts
@@ -28,8 +28,8 @@ export class QueryParamDef<QueryParams = any> {
     return this.config.serializer;
   }
 
-  get setInitialValue() {
-    return this.config.setInitialValue || false;
+  get syncInitialValue() {
+    return this.config.syncInitialValue || false;
   }
 
   serialize(controlValue: any): string | null {

--- a/projects/ngneat/bind-query-params/src/lib/QueryParamDef.ts
+++ b/projects/ngneat/bind-query-params/src/lib/QueryParamDef.ts
@@ -28,8 +28,8 @@ export class QueryParamDef<QueryParams = any> {
     return this.config.serializer;
   }
 
-  get syncOnlyInitialValue() {
-    return this.config.syncOnlyInitialValue || false;
+  get syncInitialValue() {
+    return this.config.syncInitialValue || false;
   }
 
   serialize(controlValue: any): string | null {

--- a/projects/ngneat/bind-query-params/src/lib/QueryParamDef.ts
+++ b/projects/ngneat/bind-query-params/src/lib/QueryParamDef.ts
@@ -28,8 +28,8 @@ export class QueryParamDef<QueryParams = any> {
     return this.config.serializer;
   }
 
-  get syncInitialValue() {
-    return this.config.syncInitialValue || false;
+  get syncOnlyInitialValue() {
+    return this.config.syncOnlyInitialValue || false;
   }
 
   serialize(controlValue: any): string | null {

--- a/projects/ngneat/bind-query-params/src/lib/QueryParamDef.ts
+++ b/projects/ngneat/bind-query-params/src/lib/QueryParamDef.ts
@@ -28,6 +28,10 @@ export class QueryParamDef<QueryParams = any> {
     return this.config.serializer;
   }
 
+  get setInitialValue() {
+    return this.config.setInitialValue || false;
+  }
+
   serialize(controlValue: any): string | null {
     if (this.serializer) {
       return this.serializer(controlValue);

--- a/projects/ngneat/bind-query-params/src/lib/lib.spec.ts
+++ b/projects/ngneat/bind-query-params/src/lib/lib.spec.ts
@@ -444,7 +444,7 @@ describe('BindQueryParams', () => {
         searchTerm: new FormControl(searchTerm),
       });
       spectator.component.bindQueryParams = spectator.component.factory
-        .create<Params>([{ queryKey: 'searchTerm', syncInitialValue: true }])
+        .create<Params>([{ queryKey: 'searchTerm', syncOnlyInitialValue: true }])
         .connect(spectator.component.group);
 
       tick();

--- a/projects/ngneat/bind-query-params/src/lib/lib.spec.ts
+++ b/projects/ngneat/bind-query-params/src/lib/lib.spec.ts
@@ -2,7 +2,7 @@ import { BIND_QUERY_PARAMS_OPTIONS, BindQueryParamsFactory } from '@ngneat/bind-
 import { FormControl, FormGroup } from '@angular/forms';
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { fakeAsync, tick } from '@angular/core/testing';
 import { Location } from '@angular/common';
 
@@ -103,7 +103,12 @@ describe('BindQueryParams', () => {
             }
           }),
           url: jasmine.createSpy('Router.url'),
-          events: {
+        },
+      },
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          queryParams: {
             pipe: () => {
               return {
                 subscribe: () => {},

--- a/projects/ngneat/bind-query-params/src/lib/types.ts
+++ b/projects/ngneat/bind-query-params/src/lib/types.ts
@@ -9,7 +9,7 @@ export type QueryParamParams<QueryParams = any> = {
   strategy?: 'modelToUrl' | 'twoWay';
   parser?: (value: string) => any;
   serializer?: <T>(value: T) => string;
-  setInitialValue?: boolean;
+  syncInitialValue?: boolean;
 };
 
 export interface BindQueryParamsOptions {

--- a/projects/ngneat/bind-query-params/src/lib/types.ts
+++ b/projects/ngneat/bind-query-params/src/lib/types.ts
@@ -9,7 +9,7 @@ export type QueryParamParams<QueryParams = any> = {
   strategy?: 'modelToUrl' | 'twoWay';
   parser?: (value: string) => any;
   serializer?: <T>(value: T) => string;
-  syncInitialValue?: boolean;
+  syncOnlyInitialValue?: boolean;
 };
 
 export interface BindQueryParamsOptions {

--- a/projects/ngneat/bind-query-params/src/lib/types.ts
+++ b/projects/ngneat/bind-query-params/src/lib/types.ts
@@ -9,6 +9,7 @@ export type QueryParamParams<QueryParams = any> = {
   strategy?: 'modelToUrl' | 'twoWay';
   parser?: (value: string) => any;
   serializer?: <T>(value: T) => string;
+  setInitialValue?: boolean;
 };
 
 export interface BindQueryParamsOptions {

--- a/projects/ngneat/bind-query-params/src/lib/types.ts
+++ b/projects/ngneat/bind-query-params/src/lib/types.ts
@@ -19,3 +19,7 @@ export interface ResolveParamsOption<T = any> {
   def: QueryParamDef<T>;
   value: any;
 }
+
+export interface SyncDefsOptions {
+  emitEvent: boolean;
+}

--- a/projects/ngneat/bind-query-params/src/lib/types.ts
+++ b/projects/ngneat/bind-query-params/src/lib/types.ts
@@ -9,7 +9,7 @@ export type QueryParamParams<QueryParams = any> = {
   strategy?: 'modelToUrl' | 'twoWay';
   parser?: (value: string) => any;
   serializer?: <T>(value: T) => string;
-  syncOnlyInitialValue?: boolean;
+  syncInitialValue?: boolean;
 };
 
 export interface BindQueryParamsOptions {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent {
   title = 'bindQueryParams';
 
   group = new FormGroup({
-    searchTerm: new FormControl(),
+    searchTerm: new FormControl('some search term'),
     showErrors: new FormControl(false),
     issues: new FormControl([]),
     nested: new FormGroup(
@@ -38,7 +38,7 @@ export class AppComponent {
 
   private manager = this.factory
     .create<Params>([
-      { queryKey: 'searchTerm' },
+      { queryKey: 'searchTerm', setInitialValue: true },
       { queryKey: 'showErrors', type: 'boolean' },
       { queryKey: 'issues', strategy: 'modelToUrl', type: 'array' },
       { queryKey: 'nested', path: 'nested.a' },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,7 +38,7 @@ export class AppComponent {
 
   private manager = this.factory
     .create<Params>([
-      { queryKey: 'searchTerm', setInitialValue: true },
+      { queryKey: 'searchTerm', syncInitialValue: true },
       { queryKey: 'showErrors', type: 'boolean' },
       { queryKey: 'issues', strategy: 'modelToUrl', type: 'array' },
       { queryKey: 'nested', path: 'nested.a' },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,7 +38,7 @@ export class AppComponent {
 
   private manager = this.factory
     .create<Params>([
-      { queryKey: 'searchTerm', syncInitialValue: true },
+      { queryKey: 'searchTerm', syncOnlyInitialValue: true },
       { queryKey: 'showErrors', type: 'boolean' },
       { queryKey: 'issues', strategy: 'modelToUrl', type: 'array' },
       { queryKey: 'nested', path: 'nested.a' },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,8 +38,8 @@ export class AppComponent {
 
   private manager = this.factory
     .create<Params>([
-      { queryKey: 'searchTerm', syncOnlyInitialValue: true },
-      { queryKey: 'showErrors', type: 'boolean' },
+      { queryKey: 'searchTerm' },
+      { queryKey: 'showErrors', type: 'boolean', strategy: 'modelToUrl', syncInitialValue: true },
       { queryKey: 'issues', strategy: 'modelToUrl', type: 'array' },
       { queryKey: 'nested', path: 'nested.a' },
     ])


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features) - Can't be tested
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: https://github.com/ngneat/bind-query-params/issues/14

## What is the new behavior?

You can pass a property called _setInitialValue_ to choose if bindQueryParam will inherit the formControl value

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
