### PR TITLE
fix: 🐛 match signature of custom serializer

### DIFF
--- a/projects/ngneat/bind-query-params/src/lib/types.ts
+++ b/projects/ngneat/bind-query-params/src/lib/types.ts
@@ -8,7 +8,7 @@ export type QueryParamParams<QueryParams = any> = {
   type?: ParamDefType;
   strategy?: 'modelToUrl' | 'twoWay';
   parser?: (value: string) => any;
-  serializer?: <T>(value: T) => string;
+  serializer?: (value: any) => string | null;
   syncInitialValue?: boolean;
 };
 


### PR DESCRIPTION
The default serializer is a function that takes a value of type `any` and returns `string` or
`null`. The custom serializer, however, featured an unnecessary generic and could only return a
string. This commit updates the custom serializer signature to match the default one.